### PR TITLE
fix(PersonalSettings): revert outlining key icon

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -100,7 +100,7 @@
 						@update:value="onSensitiveInput(true)"
 						@trailing-button-click="state.api_key = '' ; onSensitiveInput(true)"
 						@focus="readonly = false">
-						<KeyOutlineIcon />
+						<KeyIcon />
 					</NcTextField>
 				</div>
 				<NcNoteCard v-show="state.url === '' || state.url.includes('cloud.ibm.com')" type="info">
@@ -127,7 +127,7 @@
 						@update:value="onSensitiveInput(true)"
 						@trailing-button-click="state.project_id = '' ; onSensitiveInput(true)"
 						@focus="readonly = false">
-						<KeyOutlineIcon />
+						<KeyIcon />
 					</NcTextField>
 				</div>
 				<div class="line">
@@ -142,7 +142,7 @@
 						@update:value="onSensitiveInput(true)"
 						@trailing-button-click="state.space_id = '' ; onSensitiveInput(true)"
 						@focus="readonly = false">
-						<KeyOutlineIcon />
+						<KeyIcon />
 					</NcTextField>
 				</div>
 				<NcNoteCard type="info">
@@ -354,7 +354,7 @@
 import CloseIcon from 'vue-material-design-icons/Close.vue'
 import EarthIcon from 'vue-material-design-icons/Earth.vue'
 import HelpCircleOutlineIcon from 'vue-material-design-icons/HelpCircleOutline.vue'
-import KeyOutlineIcon from 'vue-material-design-icons/KeyOutline.vue'
+import KeyIcon from 'vue-material-design-icons/Key.vue'
 import TimerAlertOutlineIcon from 'vue-material-design-icons/TimerAlertOutline.vue'
 
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
@@ -377,7 +377,7 @@ export default {
 	name: 'AdminSettings',
 
 	components: {
-		KeyOutlineIcon,
+		KeyIcon,
 		CloseIcon,
 		EarthIcon,
 		TimerAlertOutlineIcon,

--- a/src/components/PersonalSettings.vue
+++ b/src/components/PersonalSettings.vue
@@ -28,7 +28,7 @@
 						@update:value="onSensitiveInput"
 						@trailing-button-click="state.api_key = '' ; onSensitiveInput()"
 						@focus="readonly = false">
-						<KeyOutlineIcon />
+						<KeyIcon />
 					</NcTextField>
 				</div>
 				<NcNoteCard type="info">
@@ -46,7 +46,7 @@
 						@update:value="onSensitiveInput"
 						@trailing-button-click="state.project_id = '' ; onSensitiveInput()"
 						@focus="readonly = false">
-						<KeyOutlineIcon />
+						<KeyIcon />
 					</NcTextField>
 				</div>
 				<div class="line">
@@ -61,7 +61,7 @@
 						@update:value="onSensitiveInput"
 						@trailing-button-click="state.space_id = '' ; onSensitiveInput()"
 						@focus="readonly = false">
-						<KeyOutlineIcon />
+						<KeyIcon />
 					</NcTextField>
 				</div>
 				<div v-if="!state.is_custom_service">
@@ -113,7 +113,7 @@
 
 <script>
 import InformationOutlineIcon from 'vue-material-design-icons/InformationOutline.vue'
-import KeyOutlineIcon from 'vue-material-design-icons/KeyOutline.vue'
+import KeyIcon from 'vue-material-design-icons/Key.vue'
 
 import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
 import NcNoteCard from '@nextcloud/vue/dist/Components/NcNoteCard.js'
@@ -129,7 +129,7 @@ export default {
 	name: 'PersonalSettings',
 
 	components: {
-		KeyOutlineIcon,
+		KeyIcon,
 		InformationOutlineIcon,
 		NcNoteCard,
 		NcTextField,


### PR DESCRIPTION
From previous discussions, the filled key icon is now considered to be "not filled" and is exempt from the switch.