### PR TITLE
chore: prepare 1.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-07-15
+
+### Changed
+
+- Bump max supported Nextcloud version to 35. #63
+
 ## [1.2.0] - 2026-04-13
 
 ### Changed
@@ -79,7 +85,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial app release.
 
-[Unreleased]: https://github.com/nextcloud/integration_watsonx/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/nextcloud/integration_watsonx/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/nextcloud/integration_watsonx/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/nextcloud/integration_watsonx/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/nextcloud/integration_watsonx/compare/v1.0.5...v1.1.0
 [1.0.5]: https://github.com/nextcloud/integration_watsonx/compare/v1.0.4...v1.0.5

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -37,7 +37,7 @@ Negative:
 
 Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud.com/blog/nextcloud-ethical-ai-rating/).
 ]]>	</description>
-	<version>1.2.0</version>
+	<version>1.3.0</version>
 	<licence>agpl</licence>
 	<author mail="contact@edward.ly" homepage="https://edward.ly/">Edward Ly</author>
 	<namespace>Watsonx</namespace>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -49,7 +49,7 @@ Learn more about the Nextcloud Ethical AI Rating [in our blog](https://nextcloud
 	<website>https://github.com/nextcloud/integration_watsonx</website>
 	<bugs>https://github.com/nextcloud/integration_watsonx/issues</bugs>
 	<dependencies>
-		<nextcloud min-version="30" max-version="34"/>
+		<nextcloud min-version="30" max-version="35"/>
 	</dependencies>
 	<background-jobs>
 		<job>OCA\Watsonx\Cron\CleanupQuotaDb</job>


### PR DESCRIPTION
### Changed

- Bump max supported Nextcloud version to 35. #63